### PR TITLE
bump lxml to 4.9.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-lxml==4.6.2
+lxml==4.9.4
 python-dateutil==2.8.0
 requests==2.21.0


### PR DESCRIPTION
Otherwise `pip3 install -r requirements.txt` fails on mac miserably on Python 3.13:

```
clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall -DCYTHON_CLINE_IN_TRACEBACK=0 -Isrc -Isrc/lxml/includes -I/Users/warden/.pyenv/versions/3.12.10/include/python3.12 -c src/lxml/etree.c -o build/temp.macosx-15.5-x86_64-cpython-312/src/lxml/etree.o -w -flat_namespace
      src/lxml/etree.c:289:12: fatal error: 'longintrepr.h' file not found
        289 |   #include "longintrepr.h"
            |            ^~~~~~~~~~~~~~~
      1 error generated.
      Compile failed: command '/usr/bin/clang' failed with exit code 1
      creating var/folders/cp/q5z3n3813y33qk6dw_0qyhpc0000gn/T
      cc -I/usr/include/libxml2 -c /var/folders/cp/q5z3n3813y33qk6dw_0qyhpc0000gn/T/xmlXPathInityv8qqqjy.c -o var/folders/cp/q5z3n3813y33qk6dw_0qyhpc0000gn/T/xmlXPathInityv8qqqjy.o
      cc var/folders/cp/q5z3n3813y33qk6dw_0qyhpc0000gn/T/xmlXPathInityv8qqqjy.o -lxml2 -o a.out
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]
```